### PR TITLE
delay sandbox restoration until promise resolution when wrapped returns promise

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -58,8 +58,16 @@ function configure(sinon, config) {
             } catch (e) {
                 exception = e;
             }
-
-            if (typeof oldDone !== "function") {
+            if (result != null && typeof result.then === "function" && typeof result.catch === "function") {
+                result = result.catch(function (err) {
+                    sandbox.restore();
+                    throw err;
+                }).then(function (res) {
+                    sandbox.verifyAndRestore();
+                    return res;
+                });
+            }
+            else if (typeof oldDone !== "function") {
                 if (typeof exception !== "undefined") {
                     sandbox.restore();
                     throw exception;

--- a/lib/test.js
+++ b/lib/test.js
@@ -59,6 +59,9 @@ function configure(sinon, config) {
                 exception = e;
             }
             if (result != null && typeof result.then === "function" && typeof result.catch === "function") {
+                // A test may signal that it is asynchronous by returning a promise instead of accepting 
+                // a callback. We handle here by chaining sandbox cleanup to occur after the promise 
+                // resolves or rejects.
                 result = result.catch(function (err) {
                     sandbox.restore();
                     throw err;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "license": "BSD-3-Clause",
   "devDependencies": {
+    "bluebird": "^3.3.4",
     "browserify": "^13.0.0",
     "browserify-shim": "^3.8.12",
     "buster": "0.7.18",
@@ -32,6 +33,7 @@
     "sinon": "^2.0.0-pre"
   },
   "browserify-shim": {
-    "buster": "global:buster"
+    "buster": "global:buster",
+    "bluebird": "Promise"
   }
 }

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -29,4 +29,4 @@ echo
 echo "starting buster-test (packaged)"
 mkdir -p pkg
 ./node_modules/.bin/browserify ./test/*-test.js ./test/test-helper.js --exclude buster -t browserify-shim -o pkg/sinon-test-testrunner.js
-./node_modules/buster/bin/buster-test --config test/buster-packaged.js
+./node_modules/buster/bin/buster-test -o --config test/buster-packaged.js

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -3,6 +3,7 @@
 var sinonTest = require("../");
 var buster = require("buster");
 var sinon = require("sinon");
+var Promise = require("bluebird");
 
 var nextTick = buster.nextTick;
 var assert = buster.assert;
@@ -218,7 +219,24 @@ buster.testCase("sinon-test", {
             callback();
         }).call({}, "arg1", {}, done);
     },
-
+    "promises": {
+        "cleanup on resolution": function (done) {
+            var obj = {foo: function () {}};
+            var promise = instance(function () {
+                var spy = this.spy(obj, "foo");
+                return Promise.delay(1).then(function () {
+                    obj.foo();
+                }).then(function () {
+                    assert(spy.calledOnce);
+                });
+            }).call({});
+            return promise.then(function () {
+                done();
+            }).catch(function (err) {
+                done(err);
+            });
+        }
+    },
     "verifies mocks": function () {
         var method = function () {};
         var object = { method: method };


### PR DESCRIPTION
For https://github.com/sinonjs/sinon-test/issues/6.

The test works in node. Unfortunately I am not very familiar with browserify & buster, and the test doesn't work properly there: it doesn't seem to progress on the async promise.

Thus this is not actually ready to go, but you may be able to tell me how to fix it pretty easily.