### PR TITLE
Fix #9 port throw caught exceptions from async tests from v1.17

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -59,13 +59,11 @@ function configure(sinon, config) {
                 exception = e;
             }
 
-            if (typeof oldDone !== "function") {
-                if (typeof exception !== "undefined") {
-                    sandbox.restore();
-                    throw exception;
-                } else {
-                    sandbox.verifyAndRestore();
-                }
+            if (typeof exception !== "undefined") {
+                sandbox.restore();
+                throw exception;
+            } else if (typeof oldDone !== "function") {
+                sandbox.verifyAndRestore();
             }
 
             return result;

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -94,6 +94,19 @@ buster.testCase("sinon-test", {
         }, "Error");
     },
 
+    "throws when an async method throws": function () {
+        var method = function () {};
+        var object = { method: method };
+        var fakeDone = function () {};
+
+        assert.exception(function () {
+            instance(function (done) { // eslint-disable-line no-unused-vars
+                this.stub(object, "method");
+                throw new Error();
+            }).call({}, fakeDone);
+        }, "Error");
+    },
+
     "restores stub when method throws": function () {
         var method = function () {};
         var object = { method: method };


### PR DESCRIPTION
Simply porting the merged fix from 1.17 that ensures caught errors thrown as expected.