### PR TITLE
fix #6 add support for promises

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -62,7 +62,19 @@ function configure(sinon, config) {
             if (typeof exception !== "undefined") {
                 sandbox.restore();
                 throw exception;
-            } else if (typeof oldDone !== "function") {
+            }
+
+            if (result && typeof result === "object" && typeof result.then === "function") {
+                return result.then(function sinonHandlePromiseResolve(val) {
+                    sandbox.verifyAndRestore();
+                    return val;
+                }, function sinonHandlePromiseReject(err) {
+                    sandbox.restore();
+                    throw err;
+                });
+            }
+
+            if (typeof oldDone !== "function") {
                 sandbox.verifyAndRestore();
             }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "buster": "0.7.18",
     "buster-core": "^0.6.4",
     "buster-istanbul": "^0.1.15",
+    "es6-promise": "^3.1.2",
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
     "pre-commit": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "es6-promise": "^3.1.2",
     "eslint": "^1.7.1",
     "eslint-config-defaults": "^2.1.0",
+    "phantomjs-prebuilt": "^2.1.7",
     "pre-commit": "^1.1.2",
     "sinon": "^2.0.0-pre"
   },

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -13,20 +13,20 @@ trap finish SIGINT SIGTERM EXIT
 
 echo
 echo starting buster-server
-./node_modules/buster/bin/buster-server & # fork to a subshell
+./node_modules/.bin/buster-server & # fork to a subshell
 sleep 4 # takes a while for buster server to start
 
 echo
 echo starting phantomjs
-phantomjs ./node_modules/buster/script/phantom.js &
+./node_modules/.bin/phantomjs ./node_modules/buster/script/phantom.js &
 sleep 1 # give phantomjs a second to warm up
 
 echo
 echo "starting buster-test (source)"
-./node_modules/buster/bin/buster-test --config-group coverage
+./node_modules/.bin/buster-test --config-group coverage
 
 echo
 echo "starting buster-test (packaged)"
 mkdir -p pkg
 ./node_modules/.bin/browserify ./test/*-test.js ./test/test-helper.js --exclude buster -t browserify-shim -o pkg/sinon-test-testrunner.js
-./node_modules/buster/bin/buster-test --config test/buster-packaged.js
+./node_modules/.bin/buster-test --config test/buster-packaged.js

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -108,7 +108,7 @@ buster.testCase("sinon-test", {
         }, "Error");
     },
 
-    "restores stub after promise resolves": function (done) {
+    "restores stub after promise resolves": function () {
         var object = {};
 
         var promise = instance(function () {
@@ -117,13 +117,12 @@ buster.testCase("sinon-test", {
             });
         }).call({});
 
-        promise.then(function (result) {
+        return promise.then(function (result) {
             assert.same(result, object);
-            done();
         });
     },
 
-    "restores stub after promise is resolved": function (done) {
+    "restores stub after promise is resolved": function () {
         var method = function () {};
         var object = { method: method };
 
@@ -136,13 +135,12 @@ buster.testCase("sinon-test", {
 
         assert.equals(object.method === method, false);
 
-        promise.then(function () {
+        return promise.then(function () {
             assert.same(object.method, method);
-            done();
         });
     },
 
-    "restores stub after promise is rejected": function (done) {
+    "restores stub after promise is rejected": function () {
         var method = function () {};
         var object = { method: method };
 
@@ -155,9 +153,8 @@ buster.testCase("sinon-test", {
 
         assert.equals(object.method === method, false);
 
-        promise.then(null, function (err) {
+        return promise.then(null, function (err) {
             assert.equals(err instanceof Error, true);
-            done();
         });
     },
 


### PR DESCRIPTION
Adds support for promises. If a promise is returned from the callback then stubs will not be reset until after the promise is resolved/rejected. The promise is also proxied completely so values/errors will be received by code outside of sinon.test.