### PR TITLE
Handling promises better

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -62,6 +62,7 @@ function handleAsyncFn(sandbox, result, isAsync) {
         ));
     }
 
+    // the function had an arity of 1 or more, but it was not passed a callback
     if (!isAsync) {
         finish(sandbox);
     }

--- a/lib/test.js
+++ b/lib/test.js
@@ -10,20 +10,89 @@
 
 var utils = require("./utils");
 var slice = Array.prototype.slice;
+var DEFAULT_CONFIG = {
+    injectIntoThis: true,
+    injectInto: null,
+    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+    useFakeTimers: true,
+    useFakeServer: true
+};
+
+function finish(sandbox, error, dontThrow) {
+    if (error) {
+        sandbox.restore();
+
+        if (dontThrow) {
+            return;
+        }
+
+        throw error;
+    }
+
+    sandbox.verifyAndRestore();
+}
+
+function handleFn(sandbox, result) {
+    if (result && utils.isPromise(result)) {
+        return result.then(
+            function sinonHandlePromiseResolve(value) {
+                finish(sandbox);
+
+                return value;
+            },
+            function sinonHandlePromiseReject(error) {
+                finish(
+                    sandbox,
+                    error || new Error("Promise rejected with no/falsy error")
+                );
+            }
+        );
+    }
+
+    finish(sandbox);
+
+    return result;
+}
+
+function handleAsyncFn(sandbox, result, isAsync) {
+    if (result && utils.isPromise(result)) {
+        finish(sandbox, new Error(
+            "Your test should take a callback *or* return a promise. "
+                + "It should not do both."
+        ));
+    }
+
+    if (!isAsync) {
+        finish(sandbox);
+    }
+}
 
 function configure(sinon, config) {
     if (!utils.isSinon(sinon)) {
         throw new TypeError("expected sinon object");
     }
 
-    if (!config) {
-        config = {
-            injectIntoThis: true,
-            injectInto: null,
-            properties: ["spy", "stub", "mock", "clock", "server", "requests"],
-            useFakeTimers: true,
-            useFakeServer: true
-        };
+    function callSandboxedFn(context, args, fn, handler) {
+        config = sinon.getConfig(config || DEFAULT_CONFIG);
+        config.injectInto = config.injectIntoThis && context || config.injectInto;
+        var sandbox = sinon.sandbox.create(config);
+        var done = args.length && args[args.length - 1];
+        var result;
+
+        if (typeof done === "function") {
+            args[args.length - 1] = function sinonDone(error) {
+                finish(sandbox, error, true);
+                done(error);
+            };
+        }
+
+        try {
+            result = fn.apply(context, args.concat(sandbox.args));
+        } catch (e) {
+            finish(sandbox, e);
+        }
+
+        return handler(sandbox, result, typeof done === "function");
     }
 
     return function test(callback) {
@@ -33,61 +102,14 @@ function configure(sinon, config) {
             throw new TypeError("sinon.test needs to wrap a test function, got " + type);
         }
 
-        function sinonSandboxedTest() {
-            config = sinon.getConfig(config);
-            config.injectInto = config.injectIntoThis && this || config.injectInto;
-
-            var sandbox = sinon.sandbox.create(config);
-            var args = slice.call(arguments);
-            var oldDone = args.length && args[args.length - 1];
-            var exception, result;
-
-            if (typeof oldDone === "function") {
-                args[args.length - 1] = function sinonDone(res) {
-                    if (res) {
-                        sandbox.restore();
-                    } else {
-                        sandbox.verifyAndRestore();
-                    }
-                    oldDone(res);
-                };
+        return callback.length
+            ? function sinonAsyncSandboxedTest(_) { // eslint-disable-line no-unused-vars
+                return callSandboxedFn(this, slice.call(arguments), callback, handleAsyncFn);
             }
-
-            try {
-                result = callback.apply(this, args.concat(sandbox.args));
-            } catch (e) {
-                exception = e;
+            : function sinonSandboxedTest() {
+                return callSandboxedFn(this, slice.call(arguments), callback, handleFn);
             }
-
-            if (typeof exception !== "undefined") {
-                sandbox.restore();
-                throw exception;
-            }
-
-            if (result && typeof result === "object" && typeof result.then === "function") {
-                return result.then(function sinonHandlePromiseResolve(val) {
-                    sandbox.verifyAndRestore();
-                    return val;
-                }, function sinonHandlePromiseReject(err) {
-                    sandbox.restore();
-                    throw err;
-                });
-            }
-
-            if (typeof oldDone !== "function") {
-                sandbox.verifyAndRestore();
-            }
-
-            return result;
-        }
-
-        if (callback.length) {
-            return function sinonAsyncSandboxedTest(done) { // eslint-disable-line no-unused-vars
-                return sinonSandboxedTest.apply(this, arguments);
-            };
-        }
-
-        return sinonSandboxedTest;
+        ;
     };
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,10 @@
  */
 "use strict";
 
+exports.isPromise = function (object) {
+    return typeof object === "object" && typeof object.then === "function";
+};
+
 exports.isSinon = function (obj) {
     return !!obj && typeof obj === "object" &&
         typeof obj.getConfig === "function" &&

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -329,19 +329,19 @@ module.exports = {
     },
 
     "sync tests with thenable return value": {
-        setUp: function () {
+        beforeEach: function () {
             var method = this.method = function () {};
             var object = this.object = {method: method};
             var promise = this.promise = stubPromise();
 
-            this.test = instance(function () {
+            this.sinonTest = instance(function () {
                 this.stub(object, "method");
 
                 return promise;
             });
         },
 
-        tearDown: function () {
+        afterEach: function () {
             // ensure sandbox is restored
             if (this.promise.index < this.promise.then.callCount) {
                 this.promise.resolve();
@@ -350,7 +350,7 @@ module.exports = {
 
         "should listen to returned promise": function (done) {
             var self = this;
-            var promise = self.test.call({});
+            var promise = self.sinonTest.call({});
 
             assert(promise.then.calledOnce);
             assert(promise.then.getCall(0).args.length, 2);
@@ -366,7 +366,7 @@ module.exports = {
         },
 
         "restores sandbox after promise is fulfilled": function () {
-            var promise = this.test.call({});
+            var promise = this.sinonTest.call({});
 
             promise.resolve();
 
@@ -374,7 +374,7 @@ module.exports = {
         },
 
         "restores sandbox after promise is rejected": function () {
-            var promise = this.test.call({});
+            var promise = this.sinonTest.call({});
             var error = new Error("expected");
 
             assert.exception(
@@ -389,7 +389,7 @@ module.exports = {
         },
 
         "ensures test rejects with a non-falsy value": function () {
-            var promise = this.test.call({});
+            var promise = this.sinonTest.call({});
 
             assert.exception(
                 function () {
@@ -403,11 +403,11 @@ module.exports = {
     },
 
     "sync tests with A+ promise returned": {
-        requiresSupportFor: {
-            Promise: typeof Promise !== "undefined"
-        },
+        beforeEach: function () {
+            if (typeof Promise === "undefined") {
+                this.skip();
+            }
 
-        setUp: function () {
             this.method = function () {};
             this.object = {method: this.method};
         },
@@ -494,7 +494,7 @@ module.exports = {
             });
 
 
-            return test.call({}).catch(function (error) {
+            test.call({}).catch(function (error) {
                 assert.equals(error.name, "ExpectationError");
                 assert.match(error.message, /Expected method\(1\) once/);
 
@@ -652,10 +652,6 @@ module.exports = {
         },
 
         "browser options": {
-            requiresSupportFor: {
-                "ajax/browser": typeof XMLHttpRequest !== "undefined" || typeof ActiveXObject !== "undefined"
-            },
-
             "yields server when faking xhr": function () {
                 var stubbed, mocked, server;
                 var obj = { meth: function () {} };

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -13,6 +13,35 @@ var refute = buster.refute;
 
 var instance = sinonTest.configureTest(sinon);
 
+// promise-like structure
+function stubPromise() {
+    var thenStub = sinon.stub();
+    var promise = {
+        then: thenStub,
+        index: 0,
+        resolve: function (object) {
+            var callback = thenStub.getCall(this.index++).args[0];
+            if (object) {
+                callback(object);
+            } else {
+                callback();
+            }
+        },
+        reject: function (error) {
+            var callback = thenStub.getCall(this.index++).args[1];
+            if (error) {
+                callback(error);
+            } else {
+                callback();
+            }
+        }
+    };
+
+    thenStub.returns(promise);
+
+    return promise;
+}
+
 module.exports = {
     beforeEach: function () {
         this.boundTestCase = function () {
@@ -283,6 +312,195 @@ module.exports = {
 
             callback();
         }).call({}, "arg1", {}, done);
+    },
+
+    "async tests should not allow thenables to be returned": function () {
+        var thenable = {
+            then: function () {
+            }
+        };
+        var test = instance(function (_) { // eslint-disable-line no-unused-vars
+            return thenable;
+        });
+
+        assert.exception(test, {
+            message: /callback .* promise.* both/
+        });
+    },
+
+    "sync tests with thenable return value": {
+        setUp: function () {
+            var method = this.method = function () {};
+            var object = this.object = {method: method};
+            var promise = this.promise = stubPromise();
+
+            this.test = instance(function () {
+                this.stub(object, "method");
+
+                return promise;
+            });
+        },
+
+        tearDown: function () {
+            // ensure sandbox is restored
+            if (this.promise.index < this.promise.then.callCount) {
+                this.promise.resolve();
+            }
+        },
+
+        "should listen to returned promise": function (done) {
+            var self = this;
+            var promise = self.test.call({});
+
+            assert(promise.then.calledOnce);
+            assert(promise.then.getCall(0).args.length, 2);
+            assert.isFunction(promise.then.getCall(0).args[0]);
+            assert.isFunction(promise.then.getCall(0).args[1]);
+
+            // allow any other actions to take place
+            nextTick(function () {
+                refute.same(self.object.method, self.method, "should wait to restore stubs");
+
+                done();
+            });
+        },
+
+        "restores sandbox after promise is fulfilled": function () {
+            var promise = this.test.call({});
+
+            promise.resolve();
+
+            assert.same(this.object.method, this.method);
+        },
+
+        "restores sandbox after promise is rejected": function () {
+            var promise = this.test.call({});
+            var error = new Error("expected");
+
+            assert.exception(
+                function () {
+                    promise.reject(error);
+                },
+                {message: "expected"},
+                "should re-throw error from rejected promise"
+            );
+
+            assert.same(this.object.method, this.method);
+        },
+
+        "ensures test rejects with a non-falsy value": function () {
+            var promise = this.test.call({});
+
+            assert.exception(
+                function () {
+                    promise.reject(false);
+                },
+                {message: /rejected.*falsy/}
+            );
+
+            assert.same(this.object.method, this.method);
+        }
+    },
+
+    "sync tests with A+ promise returned": {
+        requiresSupportFor: {
+            Promise: typeof Promise !== "undefined"
+        },
+
+        setUp: function () {
+            this.method = function () {};
+            this.object = {method: this.method};
+        },
+
+        "restores the sandbox when the promise is fulfilled": function (done) {
+            var self = this;
+            var expected = {};
+            var test = instance(function () {
+                var sandbox = this;
+
+                return new Promise(function (resolve) {
+                    sandbox.stub(self.object, "method");
+
+                    resolve(expected);
+                });
+            });
+
+            test.call({}).then(function (thing) {
+                assert.equals(self.object.method, self.method);
+                assert.same(thing, expected);
+
+                done();
+            });
+        },
+
+        "restores the sandbox when the promise is rejected": function (done) {
+            var self = this;
+            var test = instance(function () {
+                var sandbox = this;
+
+                return new Promise(function (_, reject) {
+                    sandbox.stub(self.object, "method");
+
+                    reject();
+                });
+            });
+
+            test.call({}).catch(function () {
+                assert.equals(self.object.method, self.method);
+
+                done();
+            });
+        },
+
+        "ensures test rejects with a non-falsy value": function (done) {
+            var self = this;
+            var test = instance(function () {
+                return Promise.reject(false);
+            });
+
+            test.call({}).catch(function (error) {
+                assert.match(error.message, /rejected.*falsy/);
+                assert.same(self.object.method, self.method);
+
+                done();
+            });
+        },
+
+        "re-throws the error if the promise is rejected": function (done) {
+            var expectedError = new Error("expected");
+            var test = instance(function () {
+                return Promise.reject(expectedError);
+            });
+
+            test.call({}).catch(function (error) {
+                assert.equals(error, expectedError);
+
+                done();
+            });
+        },
+
+        "verifies mocks when promise is resolved": function (done) {
+            var self = this;
+            var test = instance(function () {
+                var sandbox = this;
+
+                return new Promise(function (resolve) {
+                    sandbox.mock(self.object).expects("method").withExactArgs(1).once();
+
+                    self.object.method(42);
+
+                    resolve();
+                });
+            });
+
+
+            return test.call({}).catch(function (error) {
+                assert.equals(error.name, "ExpectationError");
+                assert.match(error.message, /Expected method\(1\) once/);
+
+                done();
+            });
+        }
     },
 
     "verifies mocks": function () {


### PR DESCRIPTION
Copied from the original PR: sinonjs/sinon#1128 and built on the foundation by @joelmukuthu

I'm not 100% happy with the way it turned out and I'm open to suggestions. I modeled it very closely to the way mocha.js handles the sitatuation. However, there is a big difference between mocha tests and sinon tests. In mocha, you know the moment you see the `fn`/`callback` whether the test is sync or async (based on the `fn.length > 0`). In sinon, you don't know until you're inside the test itself.

```js
function test1(stub, mock) // looks async because of fn.length
function test2(done) // looks async because of fn.length
function test3() // known synchronous
```
This made the abstraction not as clean as I had hoped.