### PR TITLE
Fixes precommit hook to not run for 0 files

### DIFF
--- a/scripts/eslint-pre-commit
+++ b/scripts/eslint-pre-commit
@@ -3,7 +3,7 @@
 git stash -q --keep-index
 
 # Test prospective commit
-git diff-index --cached HEAD --name-only --diff-filter ACMR | egrep '.js$' | xargs $(npm bin)/eslint
+git diff-index --cached HEAD --name-only --diff-filter ACMR | egrep '.js$' | xargs -i $(npm bin)/eslint {}
 RESULT=$?
 
 git stash pop -q


### PR DESCRIPTION
This just fixes a small annoyance. When you're fixing package.json or other non-js files and you go to commit, it prints the help for `eslint`, because you're calling `eslint` with no parameters. This fixes that case.