### PR TITLE
Add .npmignore to include /dist folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+coverage/
+node_modules/


### PR DESCRIPTION
Addresses #58 by making sure /dist is included in the package.
Without a .npmignore NPM will just follow the exclude patterns
dicated by .gitignore, which explicitly excluded /dist.