### PR TITLE
Remove buster for realz

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "buster": "0.7.18",
     "es6-promise": "^4.0.5",
     "eslint": "^3.7.1",
     "eslint-config-defaults": "^9.0.0",
@@ -38,6 +37,7 @@
     "nyc": "^10.1.2",
     "phantomjs-prebuilt": "^2.1.7",
     "pre-commit": "^1.1.2",
+    "referee": "^1.2.0",
     "rollup": "^0.41.4",
     "rollup-plugin-commonjs": "^8.0.2",
     "sinon": "^2.0.0-pre",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var buster = require("buster");
+var referee = require("referee");
 
-buster.referee.add("spy", {
+referee.add("spy", {
     assert: function (obj) {
         return obj !== null && typeof obj.calledWith === "function" && !obj.returns;
     },
     assertMessage: "Expected object ${0} to be a spy function"
 });
 
-buster.referee.add("stub", {
+referee.add("stub", {
     assert: function (obj) {
         return obj !== null &&
             typeof obj.calledWith === "function" &&
@@ -18,7 +18,7 @@ buster.referee.add("stub", {
     assertMessage: "Expected object ${0} to be a stub function"
 });
 
-buster.referee.add("mock", {
+referee.add("mock", {
     assert: function (obj) {
         return obj !== null &&
             typeof obj.verify === "function" &&
@@ -27,7 +27,7 @@ buster.referee.add("mock", {
     assertMessage: "Expected object ${0} to be a mock"
 });
 
-buster.referee.add("fakeServer", {
+referee.add("fakeServer", {
     assert: function (obj) {
         return obj !== null &&
             Object.prototype.toString.call(obj.requests) === "[object Array]" &&
@@ -36,7 +36,7 @@ buster.referee.add("fakeServer", {
     assertMessage: "Expected object ${0} to be a fake server"
 });
 
-buster.referee.add("clock", {
+referee.add("clock", {
     assert: function (obj) {
         return obj !== null &&
             typeof obj.tick === "function" &&

--- a/test/test-case-test.js
+++ b/test/test-case-test.js
@@ -1,14 +1,13 @@
 "use strict";
 
-var buster = require("buster");
+var referee = require("referee");
 var sinon = require("sinon");
 var sinonTestCase = require("../lib/test_case");
 
-var assert = buster.assert;
-var refute = buster.refute;
+var assert = referee.assert;
+var refute = referee.refute;
 
 var testCaseInstance;
-
 
 module.exports = {
     beforeEach: function () {

--- a/test/test-case-test.js
+++ b/test/test-case-test.js
@@ -27,23 +27,6 @@ module.exports = {
         }, "TypeError");
     },
 
-    /*
-    "only wraps functions with test prefix": testInstance(function () {
-        this.spy(sinon, "test");
-
-        var testc = {
-            testA: function () {},
-            doB: function () {}
-        };
-
-        testCaseInstance(testc);
-
-        assert.isFunction(testc.doB);
-        assert(sinon.test.calledWith(testc.testA));
-        assert.isFalse(sinon.test.calledWith(testc.doB));
-    }),
-    */
-
     "removes setUp method": function () {
         var test = { setUp: function () {} };
         var result = testCaseInstance(test);

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -1,15 +1,15 @@
 "use strict";
 
 var sinonTest = require("../");
-var buster = require("buster");
+var referee = require("referee");
 var sinon = require("sinon");
 var Promise = require("es6-promise").Promise;
 
 var nextTick = typeof process !== "undefined" && process.nextTick || function (fn) {
     setTimeout(fn, 0);
 };
-var assert = buster.assert;
-var refute = buster.refute;
+var assert = referee.assert;
+var refute = referee.refute;
 
 var instance = sinonTest.configureTest(sinon);
 


### PR DESCRIPTION
In https://github.com/sinonjs/sinon-test/commit/b6c1e062ebd873366047ce132717f608a841e6af @fearphage removed pieces of BusterJS.

This PR completes that work by replacing the devDependency for BusterJS with a devDependency on referee.

Bonus commit: remove commented out test