### PR TITLE
Remove unsupported 'cascade' option from uglifyjs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - '4.2'
-  - '6.7'
+  - '4'
+  - '6'
+  - '8'
 
 sudo: false
 
@@ -18,7 +19,7 @@ after_success:
 
 before_script:
   # we only need to run eslint once per build, so let's conserve a few resources
-  - 'if [ "x$TRAVIS_NODE_VERSION" = "x6.7" ]; then $(npm bin)/eslint .; fi'
+  - 'if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then $(npm bin)/eslint .; fi'
 
 git:
   depth: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,43 +4,548 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "acorn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+      "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.1.tgz",
+      "integrity": "sha1-q2/Yk6CZdZ2bhSIOOmQ5felGsPY=",
+      "dev": true,
+      "requires": {
+        "cross-spawn-async": "2.2.5",
+        "spawn-sync": "1.0.13"
+      }
+    },
+    "cross-spawn-async": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.2.14"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.38"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "diff": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
       "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
       "dev": true
     },
-    "es6-promise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.0.tgz",
-      "integrity": "sha1-3aA8qPn4m8WX5omEKSnee6jOvfA=",
-      "dev": true
-    },
-    "eslint": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+      "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
+      "dev": true
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.7.1.tgz",
+      "integrity": "sha1-f6qEWZ4P6kIvBLwy20kFQFGj8Ro=",
+      "dev": true,
+      "requires": {
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.8",
-        "doctrine": "2.0.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
         "escope": "3.6.0",
-        "espree": "3.4.3",
-        "esquery": "1.0.0",
+        "espree": "3.5.2",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
+        "is-my-json-valid": "2.17.1",
+        "is-resolvable": "1.0.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -51,1383 +556,12 @@
         "pluralize": "1.2.1",
         "progress": "1.1.8",
         "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
+        "shelljs": "0.6.1",
         "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
+        "strip-json-comments": "1.0.4",
         "table": "3.8.3",
         "text-table": "0.2.0",
         "user-home": "2.0.0"
-      },
-      "dependencies": {
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.1"
-          },
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-              "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-              "dev": true
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                  "dev": true
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                  "dev": true
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.1",
-            "typedarray": "0.0.6"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
-              "integrity": "sha1-hOJpZbueeFU17SVujTjpLGnwnRA=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.2",
-                "util-deprecate": "1.0.2"
-              },
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                  "dev": true
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                  "dev": true
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                  "dev": true
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                  "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-                  "dev": true
-                },
-                "string_decoder": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-                  "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "5.0.1"
-                  },
-                  "dependencies": {
-                    "safe-buffer": {
-                      "version": "5.0.1",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                      "dev": true
-                    }
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                  "dev": true
-                }
-              }
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-              "dev": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            }
-          }
-        },
-        "doctrine": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-          "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            }
-          }
-        },
-        "escope": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-          "dev": true,
-          "requires": {
-            "es6-map": "0.1.5",
-            "es6-weak-map": "2.0.2",
-            "esrecurse": "4.2.0",
-            "estraverse": "4.2.0"
-          },
-          "dependencies": {
-            "es6-map": {
-              "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-              "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-              "dev": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.23",
-                "es6-iterator": "2.0.1",
-                "es6-set": "0.1.5",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
-              },
-              "dependencies": {
-                "d": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                  "dev": true,
-                  "requires": {
-                    "es5-ext": "0.10.23"
-                  }
-                },
-                "es5-ext": {
-                  "version": "0.10.23",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-                  "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-                  "dev": true,
-                  "requires": {
-                    "es6-iterator": "2.0.1",
-                    "es6-symbol": "3.1.1"
-                  }
-                },
-                "es6-iterator": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-                  "dev": true,
-                  "requires": {
-                    "d": "1.0.0",
-                    "es5-ext": "0.10.23",
-                    "es6-symbol": "3.1.1"
-                  }
-                },
-                "es6-set": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                  "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-                  "dev": true,
-                  "requires": {
-                    "d": "1.0.0",
-                    "es5-ext": "0.10.23",
-                    "es6-iterator": "2.0.1",
-                    "es6-symbol": "3.1.1",
-                    "event-emitter": "0.3.5"
-                  }
-                },
-                "es6-symbol": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                  "dev": true,
-                  "requires": {
-                    "d": "1.0.0",
-                    "es5-ext": "0.10.23"
-                  }
-                },
-                "event-emitter": {
-                  "version": "0.3.5",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-                  "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-                  "dev": true,
-                  "requires": {
-                    "d": "1.0.0",
-                    "es5-ext": "0.10.23"
-                  }
-                }
-              }
-            },
-            "es6-weak-map": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-              "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-              "dev": true,
-              "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.23",
-                "es6-iterator": "2.0.1",
-                "es6-symbol": "3.1.1"
-              },
-              "dependencies": {
-                "d": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                  "dev": true,
-                  "requires": {
-                    "es5-ext": "0.10.23"
-                  }
-                },
-                "es5-ext": {
-                  "version": "0.10.23",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-                  "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-                  "dev": true,
-                  "requires": {
-                    "es6-iterator": "2.0.1",
-                    "es6-symbol": "3.1.1"
-                  }
-                },
-                "es6-iterator": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-                  "dev": true,
-                  "requires": {
-                    "d": "1.0.0",
-                    "es5-ext": "0.10.23",
-                    "es6-symbol": "3.1.1"
-                  }
-                },
-                "es6-symbol": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                  "dev": true,
-                  "requires": {
-                    "d": "1.0.0",
-                    "es5-ext": "0.10.23"
-                  }
-                }
-              }
-            },
-            "esrecurse": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-              "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-              "dev": true,
-              "requires": {
-                "estraverse": "4.2.0",
-                "object-assign": "4.1.1"
-              },
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "espree": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-          "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-          "dev": true,
-          "requires": {
-            "acorn": "5.0.3",
-            "acorn-jsx": "3.0.1"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-              "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
-              "dev": true
-            },
-            "acorn-jsx": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-              "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-              "dev": true,
-              "requires": {
-                "acorn": "3.3.0"
-              },
-              "dependencies": {
-                "acorn": {
-                  "version": "3.3.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                  "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "esquery": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-          "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-          "dev": true,
-          "requires": {
-            "estraverse": "4.2.0"
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        },
-        "file-entry-cache": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-          "dev": true,
-          "requires": {
-            "flat-cache": "1.2.2",
-            "object-assign": "4.1.1"
-          },
-          "dependencies": {
-            "flat-cache": {
-              "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-              "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-              "dev": true,
-              "requires": {
-                "circular-json": "0.3.1",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
-              },
-              "dependencies": {
-                "circular-json": {
-                  "version": "0.3.1",
-                  "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-                  "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
-                  "dev": true
-                },
-                "del": {
-                  "version": "2.2.2",
-                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                  "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-                  "dev": true,
-                  "requires": {
-                    "globby": "5.0.0",
-                    "is-path-cwd": "1.0.0",
-                    "is-path-in-cwd": "1.0.0",
-                    "object-assign": "4.1.1",
-                    "pify": "2.3.0",
-                    "pinkie-promise": "2.0.1",
-                    "rimraf": "2.6.1"
-                  },
-                  "dependencies": {
-                    "globby": {
-                      "version": "5.0.0",
-                      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-                      "dev": true,
-                      "requires": {
-                        "array-union": "1.0.2",
-                        "arrify": "1.0.1",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
-                      },
-                      "dependencies": {
-                        "array-union": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-                          "dev": true,
-                          "requires": {
-                            "array-uniq": "1.0.3"
-                          },
-                          "dependencies": {
-                            "array-uniq": {
-                              "version": "1.0.3",
-                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "arrify": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "is-path-cwd": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-                      "dev": true
-                    },
-                    "is-path-in-cwd": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-                      "dev": true,
-                      "requires": {
-                        "is-path-inside": "1.0.0"
-                      },
-                      "dependencies": {
-                        "is-path-inside": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-                          "dev": true,
-                          "requires": {
-                            "path-is-inside": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                      "dev": true
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                      "dev": true,
-                      "requires": {
-                        "pinkie": "2.0.4"
-                      },
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.6.1",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-                      "dev": true,
-                      "requires": {
-                        "glob": "7.1.2"
-                      }
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                  "dev": true
-                },
-                "write": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                  "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                  "dev": true,
-                  "requires": {
-                    "mkdirp": "0.5.1"
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          },
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
-            }
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
-          "dev": true
-        },
-        "ignore": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-          "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.1.0",
-            "figures": "1.7.0",
-            "lodash": "4.17.4",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-              "dev": true,
-              "requires": {
-                "restore-cursor": "1.0.1"
-              },
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                  "dev": true,
-                  "requires": {
-                    "exit-hook": "1.1.1",
-                    "onetime": "1.1.0"
-                  },
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-                      "dev": true
-                    },
-                    "onetime": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-              "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-              "dev": true
-            },
-            "figures": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-              "dev": true,
-              "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
-              },
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                  "dev": true
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                  "dev": true
-                }
-              }
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "mute-stream": "0.0.5"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                  "dev": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                      "dev": true
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-                  "dev": true
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-              "dev": true,
-              "requires": {
-                "once": "1.4.0"
-              },
-              "dependencies": {
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "dev": true,
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                  "dev": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-              "dev": true
-            }
-          }
-        },
-        "is-my-json-valid": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-          "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-          "dev": true,
-          "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "generate-function": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-              "dev": true
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-              "dev": true,
-              "requires": {
-                "is-property": "1.0.2"
-              },
-              "dependencies": {
-                "is-property": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                  "dev": true
-                }
-              }
-            },
-            "jsonpointer": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-              "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-              "dev": true
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-              "dev": true
-            }
-          }
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-          "dev": true,
-          "requires": {
-            "tryit": "1.0.3"
-          },
-          "dependencies": {
-            "tryit": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-              "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-              "dev": true
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.8.4",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-          "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "3.1.3"
-          },
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "1.0.3"
-              },
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                  "dev": true
-                }
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-              "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-              "dev": true
-            }
-          }
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          },
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-              "dev": true
-            }
-          }
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          },
-          "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-              "dev": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "natural-compare": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-          "dev": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "dev": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          },
-          "dependencies": {
-            "deep-is": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-              "dev": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-              "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-              "dev": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-              "dev": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-              "dev": true
-            }
-          }
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-          "dev": true
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-          "dev": true
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
-        },
-        "require-uncached": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-          "dev": true,
-          "requires": {
-            "caller-path": "0.1.0",
-            "resolve-from": "1.0.1"
-          },
-          "dependencies": {
-            "caller-path": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-              "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-              "dev": true,
-              "requires": {
-                "callsites": "0.2.0"
-              },
-              "dependencies": {
-                "callsites": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                  "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-                  "dev": true
-                }
-              }
-            },
-            "resolve-from": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-              "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-              "dev": true
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-          "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2",
-            "interpret": "1.0.3",
-            "rechoir": "0.6.2"
-          },
-          "dependencies": {
-            "interpret": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-              "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-              "dev": true
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-              "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-              "dev": true,
-              "requires": {
-                "resolve": "1.3.3"
-              },
-              "dependencies": {
-                "resolve": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-                  "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-                  "dev": true,
-                  "requires": {
-                    "path-parse": "1.0.5"
-                  },
-                  "dependencies": {
-                    "path-parse": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-                      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        },
-        "table": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "ajv-keywords": "1.5.1",
-            "chalk": "1.1.3",
-            "lodash": "4.17.4",
-            "slice-ansi": "0.0.4",
-            "string-width": "2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-              "dev": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              },
-              "dependencies": {
-                "co": {
-                  "version": "4.6.0",
-                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                  "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-                  "dev": true
-                }
-              }
-            },
-            "ajv-keywords": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-              "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-              "dev": true
-            },
-            "slice-ansi": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-              "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-              "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                  "dev": true
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-          "dev": true
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-              "dev": true
-            }
-          }
-        }
       }
     },
     "eslint-config-defaults": {
@@ -1435,6 +569,202 @@
       "resolved": "https://registry.npmjs.org/eslint-config-defaults/-/eslint-config-defaults-9.0.0.tgz",
       "integrity": "sha1-oJCtwTspNeP0OzzQSKknAWVOWtU=",
       "dev": true
+    },
+    "espree": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.3.0",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extract-zip": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+      "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.5.0",
+        "debug": "0.7.4",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
+          }
+        },
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
     },
     "formatio": {
       "version": "1.2.0",
@@ -1445,22 +775,554 @@
         "samsam": "1.2.1"
       }
     },
+    "fs-extra": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.9.0",
+        "is-my-json-valid": "2.17.1",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true,
+      "requires": {
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
+    },
+    "is-absolute": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+      "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+      "dev": true,
+      "requires": {
+        "is-relative": "0.1.3"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-json-valid": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+      "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
-    "just-extend": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
-      "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8=",
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "lolex": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.2.tgz",
-      "integrity": "sha1-JpS5U8nqTQE+W4v7qJHJkQJbJik=",
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+      "dev": true
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
@@ -1481,9 +1343,9 @@
       }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.1.tgz",
+      "integrity": "sha1-o4ArSqOBk0yss43nDPdxYh2o+a8=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1499,29 +1361,6 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
-        "browser-stdout": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          },
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-              "dev": true
-            }
-          }
-        },
         "debug": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
@@ -1529,26 +1368,12 @@
           "dev": true,
           "requires": {
             "ms": "0.7.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
-            }
           }
         },
         "diff": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
           "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "glob": {
@@ -1563,183 +1388,13 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
-          },
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
-            }
           }
         },
-        "growl": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
-        },
-        "json3": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-          "dev": true
-        },
-        "lodash.create": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-          "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-          "dev": true,
-          "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._basecreate": "3.0.3",
-            "lodash._isiterateecall": "3.0.9"
-          },
-          "dependencies": {
-            "lodash._baseassign": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-              "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-              "dev": true,
-              "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash.keys": "3.1.2"
-              },
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-                  "dev": true
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-                  "dev": true,
-                  "requires": {
-                    "lodash._getnative": "3.9.1",
-                    "lodash.isarguments": "3.1.0",
-                    "lodash.isarray": "3.0.4"
-                  },
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-                      "dev": true
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-                      "dev": true
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._basecreate": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-              "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-              "dev": true
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-              "dev": true
-            }
-          }
         },
         "supports-color": {
           "version": "3.1.2",
@@ -1748,43 +1403,33 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-              "dev": true
-            }
           }
         }
       }
     },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.0.1.tgz",
-      "integrity": "sha1-DakrEKhU6XwPSW9sKEWjASgLPu8=",
-      "dev": true,
-      "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.22",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
-        }
-      }
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+      "dev": true
     },
     "npm-run-all": {
       "version": "4.0.2",
@@ -2369,1395 +2014,1467 @@
         }
       }
     },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
     "nyc": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-10.3.2.tgz",
-      "integrity": "sha1-8n9NkfKp2zbCT1dP9cbv/wIz3kY=",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-10.1.2.tgz",
+      "integrity": "sha1-6nrKogojUhAQFgT059VtKEU7AnQ=",
       "dev": true,
       "requires": {
-        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "caching-transform": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-        "debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-        "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-        "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-        "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.6.tgz",
-        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
-        "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
-        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-        "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
-        "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-        "merge-source-map": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
-        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-        "spawn-wrap": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
-        "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.0.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.3.0",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.1",
+        "istanbul-lib-coverage": "1.0.1",
+        "istanbul-lib-hook": "1.0.0",
+        "istanbul-lib-instrument": "1.4.2",
+        "istanbul-lib-report": "1.0.0-alpha.3",
+        "istanbul-lib-source-maps": "1.1.0",
+        "istanbul-reports": "1.0.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.3",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.5.4",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.2.4",
+        "test-exclude": "3.3.0",
+        "yargs": "6.6.0",
+        "yargs-parser": "4.2.1"
       },
       "dependencies": {
         "align-text": {
-          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+            "kind-of": "3.1.0",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
         },
         "amdefine": {
-          "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "2.1.1",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "version": "2.2.1",
+          "bundled": true,
           "dev": true
         },
         "append-transform": {
-          "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "version": "0.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
+            "default-require-extensions": "1.0.0"
           }
         },
         "archy": {
-          "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "arr-diff": {
-          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+            "arr-flatten": "1.0.1"
           }
         },
         "arr-flatten": {
-          "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-          "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "array-unique": {
-          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "version": "0.2.1",
+          "bundled": true,
           "dev": true
         },
         "arrify": {
-          "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "version": "1.5.2",
+          "bundled": true,
           "dev": true
         },
         "babel-code-frame": {
-          "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "version": "6.20.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "2.0.0"
           }
         },
         "babel-generator": {
-          "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-          "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
+          "version": "6.21.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-            "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-            "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+            "babel-messages": "6.8.0",
+            "babel-runtime": "6.20.0",
+            "babel-types": "6.21.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6"
           }
         },
         "babel-messages": {
-          "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "version": "6.8.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+            "babel-runtime": "6.20.0"
           }
         },
         "babel-runtime": {
-          "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+          "version": "6.20.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.1"
           }
         },
         "babel-template": {
-          "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-          "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
+          "version": "6.16.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+            "babel-runtime": "6.20.0",
+            "babel-traverse": "6.21.0",
+            "babel-types": "6.21.0",
+            "babylon": "6.15.0",
+            "lodash": "4.17.4"
           }
         },
         "babel-traverse": {
-          "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-          "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
+          "version": "6.21.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
-            "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-            "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+            "babel-code-frame": "6.20.0",
+            "babel-messages": "6.8.0",
+            "babel-runtime": "6.20.0",
+            "babel-types": "6.21.0",
+            "babylon": "6.15.0",
+            "debug": "2.6.0",
+            "globals": "9.14.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
           }
         },
         "babel-types": {
-          "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-          "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
+          "version": "6.21.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+            "babel-runtime": "6.20.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.2"
           }
         },
         "babylon": {
-          "version": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-          "integrity": "sha1-N9qUiHhIi5xOPEA4iT+jMUs/yTI=",
+          "version": "6.15.0",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
-          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "version": "0.4.2",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
-          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "version": "1.1.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
           }
         },
         "braces": {
-          "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "version": "1.8.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "builtin-modules": {
-          "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true
         },
         "caching-transform": {
-          "version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.1"
           }
         },
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "version": "1.2.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "center-align": {
-          "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "version": "0.1.3",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
           }
         },
         "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "1.1.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cliui": {
-          "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
           },
           "dependencies": {
             "wordwrap": {
-              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "version": "0.0.2",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
           }
         },
         "code-point-at": {
-          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "commondir": {
-          "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
-          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "version": "0.0.1",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
-          "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-          "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+          "version": "1.3.0",
+          "bundled": true,
           "dev": true
         },
         "core-js": {
-          "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+          "version": "2.4.1",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
-          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "version": "4.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+            "lru-cache": "4.0.2",
+            "which": "1.2.12"
           }
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
-          "integrity": "sha1-qfpvvpykPPHnn3O3XAGJy7fW21o=",
+          "version": "2.6.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+            "ms": "0.7.2"
           }
         },
         "debug-log": {
-          "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "decamelize": {
-          "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "version": "1.2.0",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
-          "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+            "strip-bom": "2.0.0"
           }
         },
         "detect-indent": {
-          "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+            "repeating": "2.0.1"
           }
         },
         "error-ex": {
-          "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "version": "1.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+            "is-arrayish": "0.2.1"
           }
         },
         "escape-string-regexp": {
-          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "version": "1.0.5",
+          "bundled": true,
           "dev": true
         },
         "esutils": {
-          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "version": "2.0.2",
+          "bundled": true,
           "dev": true
         },
         "expand-brackets": {
-          "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "version": "0.1.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "expand-range": {
-          "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "version": "1.8.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+            "fill-range": "2.2.3"
           }
         },
         "extglob": {
-          "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "version": "0.3.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+            "is-extglob": "1.0.0"
           }
         },
         "filename-regex": {
-          "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "fill-range": {
-          "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "version": "2.2.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.6",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "find-cache-dir": {
-          "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
           }
         },
         "find-up": {
-          "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "version": "1.1.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "for-in": {
-          "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "version": "0.1.6",
+          "bundled": true,
           "dev": true
         },
         "for-own": {
-          "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+            "for-in": "0.1.6"
           }
         },
         "foreground-child": {
-          "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "version": "1.5.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
           }
         },
         "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "get-caller-file": {
-          "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-base": {
-          "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "version": "0.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "glob-parent": {
-          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            "is-glob": "2.0.1"
           }
         },
         "globals": {
-          "version": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-          "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+          "version": "9.14.0",
+          "bundled": true,
           "dev": true
         },
         "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "version": "4.1.11",
+          "bundled": true,
           "dev": true
         },
         "handlebars": {
-          "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz",
-          "integrity": "sha1-Irh1zT8ObL6jAxTxROgrx6cv9CA=",
+          "version": "4.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz"
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.7.5"
           },
           "dependencies": {
             "source-map": {
-              "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "version": "0.4.4",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                "amdefine": "1.0.1"
               }
             }
           }
         },
         "has-ansi": {
-          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-flag": {
-          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
-          "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+          "version": "2.1.5",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
-          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "version": "1.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "version": "2.0.3",
+          "bundled": true,
           "dev": true
         },
         "invariant": {
-          "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "version": "2.2.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+            "loose-envify": "1.3.1"
           }
         },
         "invert-kv": {
-          "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "is-arrayish": {
-          "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "version": "0.2.1",
+          "bundled": true,
           "dev": true
         },
         "is-buffer": {
-          "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+          "version": "1.1.4",
+          "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
-          "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-dotfile": {
-          "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-          "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "is-equal-shallow": {
-          "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "version": "0.1.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+            "is-primitive": "2.0.0"
           }
         },
         "is-extendable": {
-          "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true
         },
         "is-extglob": {
-          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "is-finite": {
-          "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-glob": {
-          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+            "is-extglob": "1.0.0"
           }
         },
         "is-number": {
-          "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz"
+            "kind-of": "3.1.0"
           }
         },
         "is-posix-bracket": {
-          "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true
         },
         "is-primitive": {
-          "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "is-utf8": {
-          "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "version": "0.2.1",
+          "bundled": true,
           "dev": true
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
-          "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "version": "1.1.2",
+          "bundled": true,
           "dev": true
         },
         "isobject": {
-          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            "isarray": "1.0.0"
           }
         },
         "istanbul-lib-coverage": {
-          "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-          "integrity": "sha1-ysoZ3srvNSW11jMdcB8/O3rUhSg=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.6.tgz",
-          "integrity": "sha1-wIZtHoHPLVMZJJUQEx/Bbe5JIx8=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
+            "append-transform": "0.4.0"
           }
         },
         "istanbul-lib-instrument": {
-          "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
-          "integrity": "sha1-Fp4xvGLHeIUamUOd2Zw8wSGE02A=",
+          "version": "1.4.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-            "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+            "babel-generator": "6.21.0",
+            "babel-template": "6.16.0",
+            "babel-traverse": "6.21.0",
+            "babel-types": "6.21.0",
+            "babylon": "6.15.0",
+            "istanbul-lib-coverage": "1.0.1",
+            "semver": "5.3.0"
           }
         },
         "istanbul-lib-report": {
-          "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
-          "integrity": "sha1-RExOzKmvqTz1hPVrEPGVv3aMB3A=",
+          "version": "1.0.0-alpha.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+            "async": "1.5.2",
+            "istanbul-lib-coverage": "1.0.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "rimraf": "2.5.4",
+            "supports-color": "3.2.3"
           },
           "dependencies": {
             "supports-color": {
-              "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "version": "3.2.3",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                "has-flag": "1.0.0"
               }
             }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-          "integrity": "sha1-jHcG1Jfib+62rz4MKP1bBmlZjQ4=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            "istanbul-lib-coverage": "1.0.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.5.4",
+            "source-map": "0.5.6"
           }
         },
         "istanbul-reports": {
-          "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
-          "integrity": "sha1-HvO3lYiSGc+1+tFjZfbOEI1fjGY=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz"
+            "handlebars": "4.0.6"
           }
         },
         "js-tokens": {
-          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "jsesc": {
-          "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "version": "1.3.0",
+          "bundled": true,
           "dev": true
         },
         "kind-of": {
-          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-          "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
+          "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+            "is-buffer": "1.1.4"
           }
         },
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "lcid": {
-          "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+            "invert-kv": "1.0.0"
           }
         },
         "load-json-file": {
-          "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.4",
+          "bundled": true,
           "dev": true
         },
         "longest": {
-          "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "loose-envify": {
-          "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "version": "1.3.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+            "js-tokens": "3.0.0"
+          },
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "lru-cache": {
-          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+          "version": "4.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+            "pseudomap": "1.0.2",
+            "yallist": "2.0.0"
           }
         },
         "md5-hex": {
-          "version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "version": "1.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+            "md5-o-matic": "0.1.1"
           }
         },
         "md5-o-matic": {
-          "version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true
         },
         "merge-source-map": {
-          "version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
-          "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8=",
+          "version": "1.0.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            "source-map": "0.5.6"
           }
         },
         "micromatch": {
-          "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "version": "2.3.11",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-            "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.1.0",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
           }
         },
         "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "version": "3.0.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+            "brace-expansion": "1.1.6"
           }
         },
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.0.8",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
+          "version": "0.7.2",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
-          "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+          "version": "2.3.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+            "hosted-git-info": "2.1.5",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
           }
         },
         "normalize-path": {
-          "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
-          }
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
         },
         "number-is-nan": {
-          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
-          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true
         },
         "object.omit": {
-          "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+            "for-own": "0.1.4",
+            "is-extendable": "0.1.1"
           }
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "version": "1.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "wrappy": "1.0.2"
           }
         },
         "optimist": {
-          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "version": "0.6.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
           }
         },
         "os-homedir": {
-          "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
-          "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "version": "1.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+            "lcid": "1.0.0"
           }
         },
         "parse-glob": {
-          "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "version": "3.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.2",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "parse-json": {
-          "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "version": "2.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+            "error-ex": "1.3.0"
           }
         },
         "path-exists": {
-          "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "path-parse": {
-          "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "version": "1.0.5",
+          "bundled": true,
           "dev": true
         },
         "path-type": {
-          "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
-          "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "version": "2.3.0",
+          "bundled": true,
           "dev": true
         },
         "pinkie": {
-          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "version": "2.0.4",
+          "bundled": true,
           "dev": true
         },
         "pinkie-promise": {
-          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+            "pinkie": "2.0.4"
           }
         },
         "pkg-dir": {
-          "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+            "find-up": "1.1.2"
           }
         },
         "preserve": {
-          "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+          "version": "0.2.0",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
-          "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "randomatic": {
-          "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-          "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+          "version": "1.1.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz"
+            "is-number": "2.1.0",
+            "kind-of": "3.1.0"
           }
         },
         "read-pkg": {
-          "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-            "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.3.5",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
-          "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "regenerator-runtime": {
-          "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "version": "0.10.1",
+          "bundled": true,
           "dev": true
         },
         "regex-cache": {
-          "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+          "version": "0.4.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
           }
         },
-        "remove-trailing-separator": {
-          "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-          "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
-          "dev": true
-        },
         "repeat-element": {
-          "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+          "version": "1.1.2",
+          "bundled": true,
           "dev": true
         },
         "repeat-string": {
-          "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "version": "1.6.1",
+          "bundled": true,
           "dev": true
         },
         "repeating": {
-          "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+            "is-finite": "1.0.2"
           }
         },
         "require-directory": {
-          "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "version": "2.1.1",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
-          "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
-          "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "right-align": {
-          "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "version": "0.1.3",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+            "align-text": "0.1.4"
           }
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "version": "2.5.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+            "glob": "7.1.1"
           }
         },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.3.0",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
-          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "version": "3.0.2",
+          "bundled": true,
           "dev": true
         },
         "slide": {
-          "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "version": "1.1.6",
+          "bundled": true,
           "dev": true
         },
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.6",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
-          "version": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
-          "integrity": "sha1-kg6yEadpwJPuv71bDnpdLmirLkA=",
+          "version": "1.2.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.5.4",
+            "signal-exit": "2.1.2",
+            "which": "1.2.12"
           },
           "dependencies": {
             "signal-exit": {
-              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-              "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+              "version": "2.1.2",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "spdx-correct": {
-          "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+            "spdx-license-ids": "1.2.2"
           }
         },
         "spdx-expression-parse": {
-          "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true
         },
         "spdx-license-ids": {
-          "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "version": "1.2.2",
+          "bundled": true,
           "dev": true
         },
         "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+            "is-utf8": "0.2.1"
           }
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "test-exclude": {
-          "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.0.tgz",
-          "integrity": "sha1-BMpwtzkN04yY1KADoXOAbKeZHJE=",
+          "version": "3.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
           }
         },
         "to-fast-properties": {
-          "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        },
-        "trim-right": {
-          "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "uglify-js": {
-          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
-          "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
+          "version": "2.7.5",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+            "async": "0.2.10",
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
             "yargs": {
-              "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "version": "3.10.0",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
               }
             }
           }
         },
         "uglify-to-browserify": {
-          "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
-          "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
           }
         },
         "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "version": "1.2.12",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+            "isexe": "1.1.2"
           }
         },
         "which-module": {
-          "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "window-size": {
-          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "version": "0.1.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "version": "0.0.3",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
-          "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           }
         },
         "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
-          "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "version": "1.3.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "y18n": {
-          "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "version": "3.2.1",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
-          "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "version": "6.6.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           },
           "dependencies": {
             "camelcase": {
-              "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
-              "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "version": "3.2.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
               }
             }
           }
         },
         "yargs-parser": {
-          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "version": "4.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+            "camelcase": "3.0.0"
           },
           "dependencies": {
             "camelcase": {
-              "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true
             }
           }
         }
       }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -3768,1005 +3485,138 @@
         "isarray": "0.0.1"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "phantomjs-prebuilt": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
-      "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.7.tgz",
+      "integrity": "sha1-yQvxuXcvoZeZQzH88/ZwmaloU8o=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.0.5",
         "extract-zip": "1.5.0",
-        "fs-extra": "1.0.0",
+        "fs-extra": "0.26.7",
         "hasha": "2.2.0",
         "kew": "0.7.0",
         "progress": "1.1.8",
-        "request": "2.79.0",
+        "request": "2.67.0",
         "request-progress": "2.0.1",
         "which": "1.2.14"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "pre-commit": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.1.2.tgz",
+      "integrity": "sha1-bMAcnPoBzL3rBoENhCuyAMRUeSY=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "2.0.1",
+        "which": "1.1.2"
       },
       "dependencies": {
-        "es6-promise": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
-          "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
-          "dev": true
-        },
-        "extract-zip": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-          "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "1.5.0",
-            "debug": "0.7.4",
-            "mkdirp": "0.5.0",
-            "yauzl": "2.4.1"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-              "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                      "dev": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-                  "dev": true
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
-                }
-              }
-            },
-            "yauzl": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-              "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-              "dev": true,
-              "requires": {
-                "fd-slicer": "1.0.1"
-              },
-              "dependencies": {
-                "fd-slicer": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-                  "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-                  "dev": true,
-                  "requires": {
-                    "pend": "1.2.0"
-                  },
-                  "dependencies": {
-                    "pend": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-                      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-              "dev": true
-            },
-            "jsonfile": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-              "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.11"
-              }
-            },
-            "klaw": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-              "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.11"
-              }
-            }
-          }
-        },
-        "hasha": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-          "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-          "dev": true,
-          "requires": {
-            "is-stream": "1.1.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "is-stream": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              },
-              "dependencies": {
-                "pinkie": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "kew": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-          "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-          "dev": true
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-              "dev": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-              "dev": true
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-              "dev": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-              "dev": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              },
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                  "dev": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-              "dev": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-              "dev": true
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-              "dev": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
-              },
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                  "dev": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-              "dev": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.9.0",
-                "is-my-json-valid": "2.16.0",
-                "pinkie-promise": "2.0.1"
-              },
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                      "dev": true
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                      "dev": true
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                  "dev": true,
-                  "requires": {
-                    "graceful-readlink": "1.0.1"
-                  },
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-                      "dev": true
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.16.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-                  "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-                  "dev": true,
-                  "requires": {
-                    "generate-function": "2.0.0",
-                    "generate-object-property": "1.2.0",
-                    "jsonpointer": "4.0.1",
-                    "xtend": "4.0.1"
-                  },
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                      "dev": true
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                      "dev": true,
-                      "requires": {
-                        "is-property": "1.0.2"
-                      },
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-                      "dev": true
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                      "dev": true
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                  "dev": true,
-                  "requires": {
-                    "pinkie": "2.0.4"
-                  },
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-              "dev": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                  "dev": true,
-                  "requires": {
-                    "boom": "2.10.1"
-                  }
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                  "dev": true
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.1"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                  "dev": true
-                },
-                "jsprim": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                  "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                  "dev": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.0.2",
-                    "json-schema": "0.2.3",
-                    "verror": "1.3.6"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "dev": true
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                      "dev": true
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                      "dev": true
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                      "dev": true,
-                      "requires": {
-                        "extsprintf": "1.0.2"
-                      }
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.1",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                  "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-                  "dev": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  },
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                      "dev": true
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "dev": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "0.14.5"
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "0.1.1"
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-              "dev": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-              "dev": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-              "dev": true
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-              "dev": true,
-              "requires": {
-                "mime-db": "1.27.0"
-              },
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.27.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                  "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-                  "dev": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-              "dev": true
-            },
-            "qs": {
-              "version": "6.3.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-              "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-              "dev": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-              "dev": true
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-              "dev": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                  "dev": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-              "dev": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-              "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
-              "dev": true
-            }
-          }
-        },
-        "request-progress": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-          "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-          "dev": true,
-          "requires": {
-            "throttleit": "1.0.0"
-          },
-          "dependencies": {
-            "throttleit": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-              "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-              "dev": true
-            }
-          }
-        },
         "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.1.2.tgz",
+          "integrity": "sha1-SGxIr23+zHp9z5xlWs8QjS3L3z0=",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-              "dev": true
-            }
+            "is-absolute": "0.1.7"
           }
         }
       }
     },
-    "pre-commit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "qs": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
+      "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "spawn-sync": "1.0.15",
-        "which": "1.2.14"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.2.14"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-              "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-              "dev": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-                  "dev": true
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-                  "dev": true
-                }
-              }
-            },
-            "shebang-command": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-              "dev": true,
-              "requires": {
-                "shebang-regex": "1.0.0"
-              },
-              "dependencies": {
-                "shebang-regex": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "spawn-sync": {
-          "version": "1.0.15",
-          "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-          "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "os-shim": "0.1.3"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.1",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
-                  "integrity": "sha1-hOJpZbueeFU17SVujTjpLGnwnRA=",
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "safe-buffer": "5.1.1",
-                    "string_decoder": "1.0.2",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-                      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-                      "dev": true,
-                      "requires": {
-                        "safe-buffer": "5.0.1"
-                      },
-                      "dependencies": {
-                        "safe-buffer": {
-                          "version": "5.0.1",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-                  "dev": true
-                }
-              }
-            },
-            "os-shim": {
-              "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-              "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-              "dev": true
-            }
-          }
-        },
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-              "dev": true
-            }
-          }
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         }
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
       }
     },
     "referee": {
@@ -4800,32 +3650,85 @@
         }
       }
     },
-    "rollup": {
-      "version": "0.41.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.41.6.tgz",
-      "integrity": "sha1-4NBUl4d6OYwQTYFtJzOnGKepTio=",
+    "request": {
+      "version": "2.67.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+      "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
       "dev": true,
       "requires": {
-        "source-map-support": "0.4.15"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.4.15",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-          "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.6",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-              "dev": true
-            }
-          }
-        }
+        "aws-sign2": "0.6.0",
+        "bl": "1.0.3",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "1.0.1",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.8.2",
+        "qs": "5.2.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.2.2",
+        "tunnel-agent": "0.4.3"
+      }
+    },
+    "request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "dev": true,
+      "requires": {
+        "throttleit": "1.0.0"
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "rollup": {
+      "version": "0.41.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.41.4.tgz",
+      "integrity": "sha1-qXBYAXYyn56thoVNf9TEbedSrvg=",
+      "dev": true,
+      "requires": {
+        "source-map-support": "0.4.18"
       }
     },
     "rollup-plugin-commonjs": {
@@ -5271,27 +4174,278 @@
         }
       }
     },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
     "samsam": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
       "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true
+    },
     "sinon": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.1.0.tgz",
-      "integrity": "sha512-cuR8dtB/EPuBzIyLrhONxEjbnkLm8EqtQ8IBCJa9+BdoDESCVMgFuF8I7I3+R8Lgq69PjyII3iPaIlWpwZd1ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.6.tgz",
+      "integrity": "sha1-nLNGvdsYDWioBEKf/hSXjX+v1ik=",
       "dev": true,
       "requires": {
         "diff": "3.3.0",
         "formatio": "1.2.0",
-        "lolex": "2.1.2",
-        "native-promise-only": "0.8.1",
-        "nise": "1.0.1",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.2.1",
-        "text-encoding": "0.6.4",
-        "type-detect": "4.0.3"
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.6"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "just-extend": {
+          "version": "1.1.27",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+          "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+          "dev": true
+        },
+        "lolex": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+          "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+          "dev": true
+        },
+        "nise": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+          "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+          "dev": true,
+          "requires": {
+            "formatio": "1.2.0",
+            "just-extend": "1.1.27",
+            "lolex": "1.6.0",
+            "path-to-regexp": "1.7.0",
+            "text-encoding": "0.6.4"
+          },
+          "dependencies": {
+            "lolex": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+              "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.6.tgz",
+          "integrity": "sha512-qZ3bAurt2IXGPR3c57PyaSYEnQiLRwPeS60G9TahElBZsdOABo+iKYch/PhRjSTZJ5/DF08x43XMt9qec2g3ig==",
+          "dev": true
+        }
+      }
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "spawn-sync": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
+      "integrity": "sha1-kECRua1IoPOvsOhHUhVMAegv2Ng=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "os-shim": "0.1.3"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "text-encoding": {
@@ -5300,45 +4454,151 @@
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
-    "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+      "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.0.19",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.19.tgz",
-      "integrity": "sha1-qx3+KhcTYbgfqf+zODRh6jhFV+0=",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.7.tgz",
+      "integrity": "sha1-XMqcFKuuLdYM7M332jxnLMgGnOw=",
       "dev": true,
       "requires": {
         "commander": "2.9.0",
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
+      }
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          },
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-              "dev": true
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
+      }
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,20 +28,20 @@
   },
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "es6-promise": "^4.0.5",
-    "eslint": "^3.7.1",
-    "eslint-config-defaults": "^9.0.0",
-    "mkdirp": "^0.5.1",
-    "mocha": "^3.4.1",
-    "npm-run-all": "^4.0.2",
-    "nyc": "^10.1.2",
-    "phantomjs-prebuilt": "^2.1.7",
-    "pre-commit": "^1.1.2",
-    "referee": "^1.2.0",
-    "rollup": "^0.41.4",
-    "rollup-plugin-commonjs": "^8.0.2",
+    "es6-promise": "4.0.5",
+    "eslint": "3.7.1",
+    "eslint-config-defaults": "9.0.0",
+    "mkdirp": "0.5.1",
+    "mocha": "3.4.1",
+    "npm-run-all": "4.0.2",
+    "nyc": "10.1.2",
+    "phantomjs-prebuilt": "2.1.7",
+    "pre-commit": "1.1.2",
+    "referee": "1.2.0",
+    "rollup": "0.41.4",
+    "rollup-plugin-commonjs": "8.0.2",
     "sinon": "4.x.x",
-    "uglify-js": "^3.0.7"
+    "uglify-js": "3.0.7"
   },
   "peerDependencies": {
     "sinon": "2.x - 4.x"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "run-s build:dist-folder build:bundle",
-    "build:bundle": "rollup -c | uglifyjs --mangle --compress if_return,dead_code,unsafe,unsafe_comps,join_vars,comparisons,loops,collapse_vars,cascade,pure_getters > dist/sinon-test.js",
+    "build:bundle": "rollup -c | uglifyjs --mangle --compress if_return,dead_code,unsafe,unsafe_comps,join_vars,comparisons,loops,collapse_vars,pure_getters > dist/sinon-test.js",
     "build:dist-folder": "mkdirp dist",
     "coverage": "nyc report --reporter text-lcov | coveralls",
     "test": "nyc mocha",


### PR DESCRIPTION
'cascade' was removed in https://github.com/mishoo/UglifyJS2/commit/ef618332ea92db57e59f90f166035a0e7cf8a509, which was part of `uglifyjs@3.3.7`, which
is allowed by `"uglify-js": "^3.0.7"` in `package.json`.

Considering that removing the `cascade` option is a breaking change, that commit should have been released as a new MAJOR version, which means our build failures would have been avoided.

It is probably time to lock down our dependencies properly as even the
most innocent mistake will cause unexpected work for us.