### PR TITLE
Add files section to package.json to prevent unnecesary bloat of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "type": "git",
     "url": "http://github.com/sinonjs/sinon-test.git"
   },
+  "files": [
+    "dist/",
+    "lib/"
+  ],
   "license": "BSD-3-Clause",
   "devDependencies": {
     "es6-promise": "4.0.5",


### PR DESCRIPTION
This prevents unnecessary files to be published to the npm registry, saving bandwidth and speeding up installs for everyone.

#### Before

```text
du -h sinon-test-2.1.2.tgz
 44K	sinon-test-2.1.2.tgz
```

#### After 

```text
du -h sinon-test-2.1.2.tgz
8.0K	sinon-test-2.1.2.tgz
```

This package barely gets 10k downloads/month ... but I am sure that some of those users will still be happy :)

#### How to verify

1. Check out this branch
1. `npm pack`
1. Expand the package
1. Observe that both `lib/` and `dist/` are in the package