### PR TITLE
Integration tests for bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 
 after_success:
   - npm run coverage
+  - npm run integration-test
 
 before_script:
   # we only need to run eslint once per build, so let's conserve a few resources

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "build:dist-folder": "mkdirp dist",
     "coverage": "nyc report --reporter text-lcov | coveralls",
     "test": "nyc mocha",
+    "//integration-test": "This cannot run as a prepare step, as it will trigger a loop",
+    "integration-test": "test-repos/do-test.sh",
     "lint": "eslint .",
     "prepare": "run-p test lint build",
-    "preversion": "./scripts/preversion.sh"
+    "preversion": "test-repos/do-test.sh && ./scripts/preversion.sh"
   },
   "greenkeeper": {
     "ignore": [

--- a/test-repos/.gitignore
+++ b/test-repos/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+test*js

--- a/test-repos/cjs-pre.js
+++ b/test-repos/cjs-pre.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+var sinon = require("sinon");
+var sinonTestFactory = require("sinon-test");
+var assert = require("assert");

--- a/test-repos/do-test.sh
+++ b/test-repos/do-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e;
+
+# make sure we can call this script from everywhere and still have relative paths working
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$SCRIPT_DIR" > /dev/null
+
+# build test files
+cat esm-pre.mjs test-body.js > test.mjs
+cat cjs-pre.js test-body.js > test.js
+cat esm-bundle-pre.mjs test-body.js > test-bundle.mjs
+cat umd-bundle-pre.js test-body.js > test-bundle.js
+
+cd ..
+npm link # create a global symlink to the local sinon-test project
+cd "$SCRIPT_DIR"
+
+npm install
+npm link sinon-test # use local version
+npm test

--- a/test-repos/esm-bundle-pre.mjs
+++ b/test-repos/esm-bundle-pre.mjs
@@ -1,0 +1,3 @@
+import sinon from 'sinon';
+import sinonTestFactory from 'sinon-test';
+import assert from 'assert';

--- a/test-repos/esm-pre.mjs
+++ b/test-repos/esm-pre.mjs
@@ -1,0 +1,3 @@
+import sinon from 'sinon';
+import sinonTestFactory from 'sinon-test';
+import assert from 'assert';

--- a/test-repos/package.json
+++ b/test-repos/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-integration",
+  "version": "1.0.0",
+  "description": "Tests the integration using other consumers",
+  "dependencies": {
+    "esm": "^3.0.82",
+    "sinon-test": "^2.2.1"
+  },
+  "scripts": {
+    "test": "node -r esm test.mjs && node test.js && node -r esm test-bundle.mjs && node test-bundle.js"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test-repos/test-body.js
+++ b/test-repos/test-body.js
@@ -1,0 +1,20 @@
+/* eslint-disable */
+var sinonTest = sinonTestFactory(sinon);
+
+var testFramework = {
+    "the usual suspects should be present": sinonTest(
+        function myTestFunction() {
+            ["stub", "spy", "mock"].forEach(function(func) {
+                assert.equal(typeof this[func], "function");
+            }, this);
+            ["clock", "server"].forEach(function(name) {
+                assert.equal(typeof this[name], "object");
+            }, this);
+        }
+    ),
+    "basic functionality should work": sinonTest(function myTestFunction() {
+        assert.equal(this.stub().returns(42)(), 42);
+    })
+};
+
+for (var test in testFramework) testFramework[test].call(testFramework);

--- a/test-repos/umd-bundle-pre.js
+++ b/test-repos/umd-bundle-pre.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+var sinon = require("sinon");
+var sinonTestFactory = require("sinon-test/dist/sinon-test");
+var assert = require("assert");


### PR DESCRIPTION
Runs as part of the `preversion` step. Tests both CJS and ESM bundle, using both the direct paths as well as the implicit paths in package.json.

To actually make it run, I also updated our Travis config to run it after the other scripts.