### PR TITLE
Remove the built-in default config

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,9 +1,0 @@
-"use strict";
-
-module.exports = {
-    injectIntoThis: true,
-    injectInto: null,
-    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
-    useFakeTimers: true,
-    useFakeServer: true
-};

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var defaultConfig = require("./default-config");
-
-module.exports = function getConfig(custom) {
+module.exports = function getConfig(defaultConfig, custom) {
     var config = {};
     var prop;
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -76,7 +76,7 @@ function configure(sinon, config) {
     var sandboxFactory = sinon.createSandbox || sinon.sandbox.create;
 
     function callSandboxedFn(context, args, fn, handler) {
-        config = getConfig(config);
+        config = getConfig(sinon.defaultConfig, config);
         config.injectInto = config.injectIntoThis && context || config.injectInto;
         var sandbox = sandboxFactory(config);
         var done = args.length && args[args.length - 1];


### PR DESCRIPTION
The built-in default config had exactly the same content as
the default config in the main sinon project. Instad of duplicating
the content when updating it, just use the original.

Related to sinonjs/sinon#1994, which would otherwise imply
needing to update the default config in `sinon-test`.