### PR TITLE
removed conditional from `npm install` procedure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,16 +21,9 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-npm-{{ checksum "package-lock.json" }}
       - run:
           name: Install dependencies
           command: npm ci
-      - save_cache:
-          key: v1-npm-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
       - *persist-step
 
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,7 @@ jobs:
             - v1-npm-{{ checksum "package-lock.json" }}
       - run:
           name: Install dependencies
-          command: |
-            if [ ! -d node_modules ]; then
-                npm ci
-            fi
+          command: npm ci
       - save_cache:
           key: v1-npm-{{ checksum "package-lock.json" }}
           paths:


### PR DESCRIPTION
This should make install failures consistent and more reliable... unlike how it is now.

Compare #119 (passing) and #120 (failing). The difference is one is running `npm ci` and the other is not. Also caching `node_modules` makes no sense since the very first thing `npm ci` does is remove the node modules directory.