### PR TITLE
Revert "removed conditional from `npm install` procedure"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,19 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-npm-{{ checksum "package-lock.json" }}
       - run:
           name: Install dependencies
-          command: npm ci
+          command: |
+            if [ ! -d node_modules ]; then
+                npm ci
+            fi
+      - save_cache:
+          key: v1-npm-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
       - *persist-step
 
   lint:


### PR DESCRIPTION
Reverts sinonjs/sinon-test#121

We have it. We know it worked. Removing it didn't change anything for the better. And [by request](https://github.com/sinonjs/sinon-test/pull/121#issuecomment-537477435), we want it back.