### PR TITLE
Support Sinon 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "sinon": "^9.0.0"
   },
   "peerDependencies": {
-    "sinon": "2.x - 9.x"
+    "sinon": "2.x - 10.x"
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --check",


### PR DESCRIPTION
Sinon 10.0.0 was released a few weeks ago, but it's not yet supported in `peerDependencies`.

A full list of changes between the last version of 9.x and 10.0.1 [can be found here](https://github.com/sinonjs/sinon/compare/v9.2.4...v10.0.1), but based on the changelog it seems most changes are documentation or dependency updates with one additional main callout: "Use @sinonjs/eslint-config@4 => Adopts ES2017 => Drops support for IE 11, Legacy Edge and legacy Safari".